### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,22 @@
 {
   "nodes": {
+    "labwc-fork": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1783437749,
+        "narHash": "sha256-bUIPywGhlYRYVsqiJzQUODSrvpE0JXsJGPr+k5TDYjI=",
+        "owner": "mateoalfaro",
+        "repo": "labwc",
+        "rev": "ee34bbe0b864c03f02003822155422c3d04d2d7c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mateoalfaro",
+        "ref": "main",
+        "repo": "labwc",
+        "type": "github"
+      }
+    },
     "labwc-src": {
       "flake": false,
       "locked": {
@@ -34,6 +51,7 @@
     },
     "root": {
       "inputs": {
+        "labwc-fork": "labwc-fork",
         "labwc-src": "labwc-src",
         "nixpkgs": "nixpkgs",
         "singularity-desktop-src": "singularity-desktop-src",
@@ -79,11 +97,11 @@
     "singularity-shell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1783257637,
-        "narHash": "sha256-wVs8WvvTObsrNEvh3TO3trA72AvVRogcPHne+a+63X4=",
+        "lastModified": 1783438487,
+        "narHash": "sha256-aVO1Xdt9XpzK6NuUIL44tFduWnWUOG2Ux6K2rN6LP4E=",
         "owner": "mateoalfaro",
         "repo": "singularity-shell",
-        "rev": "e1c81253877ee095bae16d26ceada87dc997c2c0",
+        "rev": "b885e15a79276ed37400b0cbf9dcfb3d58ce9a97",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated `nix flake update`.

Review the diff and check that the CI build passes before merging.