### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -63,11 +63,11 @@
     "singularity-desktop-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1787323062,
-        "narHash": "sha256-b6idXgLelyluM3RMaR18E3Xa2vubQeL5CuSSL4+o4iM=",
+        "lastModified": 1787427115,
+        "narHash": "sha256-LmXJHK4KCC28ZzNFXHekWrraPjmTxUGD92aXoyB/Yr0=",
         "ref": "refs/heads/master",
-        "rev": "a2d2d2960b6155742c585ac74d3f7fe89cceafba",
-        "revCount": 236,
+        "rev": "82e5fb104929af913b400859c972f95f4b3af753",
+        "revCount": 237,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/singularityos-lab/singularity-desktop.git"


### PR DESCRIPTION
Automated `nix flake update`.

Review the diff and check that the CI build passes before merging.