### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787498568,
-        "narHash": "sha256-9i/VTdusq/+NM/tz+J1Re+ojkMB8MBf0QshnYfzHz30=",
+        "lastModified": 1787736819,
+        "narHash": "sha256-cV5xEJJK3BvhU8rEd4mC9UsmDi5qscv/kzGPhBRC5WA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "56c02bc00adcf003215cc4bd996d6efaf4cff188",
+        "rev": "9fbb54b33e91ee4ca368e35a78e0613c720600b3",
         "type": "github"
       },
       "original": {
@@ -63,11 +63,11 @@
     "singularity-desktop-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1787816662,
-        "narHash": "sha256-4Q6lU+9BOStvN5ivkIC4o+nZT1f7Ed+/xn97lspXAB4=",
+        "lastModified": 1787860808,
+        "narHash": "sha256-GvmxdV9f7LOjqcOM9RAnP5DeOKQFcqHOE8fpdo3tE9k=",
         "ref": "refs/heads/master",
-        "rev": "de4b5fbf9d3635a78979da3ee7167ec3dbcb4567",
-        "revCount": 240,
+        "rev": "9793682c65013f51ae6278245b1ad97ab23057ef",
+        "revCount": 244,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/singularityos-lab/singularity-desktop.git"


### PR DESCRIPTION
Automated `nix flake update`.

Review the diff and check that the CI build passes before merging.